### PR TITLE
Blog app: add authorization rules

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'jbuilder'
 
 gem 'devise'
 
+gem 'cancancan'
+
 # Use Redis adapter to run Action Cable in production
 # gem "redis", ">= 4.0.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
     bootsnap (1.17.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    cancancan (3.5.0)
     capybara (3.39.2)
       addressable
       matrix
@@ -304,6 +305,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  cancancan
   capybara
   debug
   devise

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,3 +15,8 @@
 .comment-btn {
   float: left;
 }
+
+.p {
+  margin: 0;
+  padding: 0;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
       u.permit(:name, :email, :bio, :photo, :password, :password_confirmation)
     end
     devise_parameter_sanitizer.permit(:account_update) do |u|
-      u.permit(:name, :email, :bio, :photo, :password, :current_password)
+      u.permit(:name, :email, :bio, :photo, :password, :current_password, :role)
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,10 +9,9 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up) do |u|
       u.permit(:name, :email, :bio, :photo, :password, :password_confirmation)
     end
-    
+
     devise_parameter_sanitizer.permit(:account_update) do |u|
       u.permit(:name, :email, :bio, :photo, :password, :current_password, :role)
     end
-    
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,8 +9,10 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up) do |u|
       u.permit(:name, :email, :bio, :photo, :password, :password_confirmation)
     end
+    
     devise_parameter_sanitizer.permit(:account_update) do |u|
       u.permit(:name, :email, :bio, :photo, :password, :current_password, :role)
     end
+    
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -21,7 +21,6 @@ class CommentsController < ApplicationController
     end
   end
 
-
   def destroy
     @user = User.find_by_id(params[:user_id])
     @post = Post.find_by_id(params[:post_id])
@@ -41,7 +40,5 @@ class CommentsController < ApplicationController
   def comment_params
     params.require(:comment).permit(:text)
   end
-
-
 
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,6 @@
 class CommentsController < ApplicationController
+  load_and_authorize_resource
+
   def new
     @user = current_user
     @post = Post.find(params[:post_id])
@@ -12,7 +14,26 @@ class CommentsController < ApplicationController
 
     @user = Post.find(params[:post_id]).author
 
-    redirect_to user_posts_path(@user)
+    if @comment.save
+      redirect_to user_posts_path(@user), notice: 'Comment was successfully created.'
+    else
+      redirect_to user_posts_path(@user), alert: 'Error creating comment.'
+    end
+  end
+
+
+  def destroy
+    @user = User.find_by_id(params[:user_id])
+    @post = Post.find_by_id(params[:post_id])
+    @comment = Comment.find_by_id(params[:id])
+
+    if @comment.destroy
+      @comment.post.decrement!(:comments_counter)
+      redirect_to user_post_path(@user, @post), notice: 'Comment was successfully deleted.'
+    else
+      redirect_to user_post_path(@user, @post), alert: 'Error deleting comment.'
+    end
+
   end
 
   private
@@ -20,4 +41,7 @@ class CommentsController < ApplicationController
   def comment_params
     params.require(:comment).permit(:text)
   end
+
+
+
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -32,7 +32,6 @@ class CommentsController < ApplicationController
     else
       redirect_to user_post_path(@user, @post), alert: 'Error deleting comment.'
     end
-
   end
 
   private
@@ -40,5 +39,4 @@ class CommentsController < ApplicationController
   def comment_params
     params.require(:comment).permit(:text)
   end
-
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,6 @@
 class PostsController < ApplicationController
+  load_and_authorize_resource
+
   def index
     @user = User.find_by_id(params[:user_id])
     @posts = @user.posts.includes(:comments) if @user
@@ -26,4 +28,16 @@ class PostsController < ApplicationController
   def post_params
     params.require(:post).permit(:title, :text)
   end
+
+  def destroy
+    @post = Post.find_by_id(params[:id])
+    @user = User.find_by_id(params[:user_id])
+    if @post.destroy
+      @post.author.decrement!(:posts_counter)
+      redirect_to user_posts_path(@user), notice: 'Post was successfully deleted.'
+    else
+      redirect_to user_posts_path(@user), alert: 'Error deleting post.'
+    end
+  end
+
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -39,5 +39,4 @@ class PostsController < ApplicationController
       redirect_to user_posts_path(@user), alert: 'Error deleting post.'
     end
   end
-
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  load_and_authorize_resource
+
   def index
     @users = User.all
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,10 +1,7 @@
-# frozen_string_literal: true
-
 class Ability
   include CanCan::Ability
 
   def initialize(user)
-
     can :read, Post # anyone can read posts
 
     return unless user.present? # if the user is not logged in, stop here
@@ -17,7 +14,7 @@ class Ability
     can :destroy, Comment, user_id: user.id # if the user is logged in can delete his own comments
 
     return unless user.role == 'admin' # if the user is not an admin, stop here
+
     can :manage, :all # if the user is an admin, can manage all
-  
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+
+    can :read, Post # anyone can read posts
+
+    return unless user.present? # if the user is not logged in, stop here
+
+    can :create, Post # if the user is logged in can create posts
+    can :create, Comment # if the user is logged in can create comments
+    can :read, User # if the user is logged in can read other users profiles
+
+    can :destroy, Post, author_id: user.id # if the user is logged in can delete his own posts
+    can :destroy, Comment, user_id: user.id # if the user is logged in can delete his own comments
+
+    return unless user.role == 'admin' # if the user is not an admin, stop here
+    can :manage, :all # if the user is an admin, can manage all
+
+    # Define abilities for the user here. For example:
+    #
+    #   return unless user.present?
+    #   can :read, :all
+    #   return unless user.admin?
+    #   can :manage, :all
+    #
+    # The first argument to `can` is the action you are giving the user
+    # permission to do.
+    # If you pass :manage it will apply to every action. Other common actions
+    # here are :read, :create, :update and :destroy.
+    #
+    # The second argument is the resource the user can perform the action on.
+    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+    # class of the resource.
+    #
+    # The third argument is an optional hash of conditions to further filter the
+    # objects.
+    # For example, here the user can only update published articles.
+    #
+    #   can :update, Article, published: true
+    #
+    # See the wiki for details:
+    # https://github.com/CanCanCommunity/cancancan/blob/develop/docs/define_check_abilities.md
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -18,24 +18,6 @@ class Ability
 
     return unless user.role == 'admin' # if the user is not an admin, stop here
     can :manage, :all # if the user is an admin, can manage all
-
   
-    # The first argument to `can` is the action you are giving the user
-    # permission to do.
-    # If you pass :manage it will apply to every action. Other common actions
-    # here are :read, :create, :update and :destroy.
-    #
-    # The second argument is the resource the user can perform the action on.
-    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
-    # class of the resource.
-    #
-    # The third argument is an optional hash of conditions to further filter the
-    # objects.
-    # For example, here the user can only update published articles.
-    #
-    #   can :update, Article, published: true
-    #
-    # See the wiki for details:
-    # https://github.com/CanCanCommunity/cancancan/blob/develop/docs/define_check_abilities.md
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -19,13 +19,7 @@ class Ability
     return unless user.role == 'admin' # if the user is not an admin, stop here
     can :manage, :all # if the user is an admin, can manage all
 
-    # Define abilities for the user here. For example:
-    #
-    #   return unless user.present?
-    #   can :read, :all
-    #   return unless user.admin?
-    #   can :manage, :all
-    #
+  
     # The first argument to `can` is the action you are giving the user
     # permission to do.
     # If you pass :manage it will apply to every action. Other common actions

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -25,6 +25,11 @@
     <%= f.text_field :photo, class: 'form-control', autofocus: true, autocomplete: "photo" %>
   </div>
 
+  <div class="field mb-2">
+    <%= f.label :role, class: 'form-label' %><br />
+    <%= f.text_field :role, class: 'form-control', autofocus: true, autocomplete: "role" %>
+  </div>
+
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
   <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -32,7 +32,10 @@
         <% end %>
         <div class="comment-like">
             <%= link_to 'Add Comment',  new_user_post_comment_path(@user, post), class: 'col-md-3 m-3 btn btn-secondary comment-btn' %>
-            <%= button_to 'Like',  user_post_likes_path(@user, post), method: :post, class: 'col-md-2 m-3 btn btn-secondary' %>
+            <%= button_to 'Like',  user_post_likes_path(@user, post), method: :post, class: 'col-md-2 m-3 btn btn-secondary comment-btn' %>
+        <% if can? :destroy, post %>
+            <%= button_to 'Delete Post', user_post_path(@user, post), method: :delete, data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, class: 'col-md-2 m-3 btn btn-danger col-md-3' %>
+        <% end %>
         </div>
     </div>
 
@@ -44,11 +47,12 @@
     </div>
     <% end %>
     <% end %>
-      <div class="text-center mt-3 mb-5">
-        <%= link_to 'Create New Post', new_user_post_path(user_id: @user.id) , class: 'btn btn-success' %>
-    </div>
 
     <% else %>
     <p style="color:blue">There are currently no posts for this user in the system.</p>
     <% end %>
+
+     <div class="text-center mt-3">
+        <%= link_to 'Create New Post', new_user_post_path(user_id: @user) , class: 'btn btn-success' %>
+    </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -8,9 +8,13 @@
     </div>
 
     <div class="card mb-2">
-        <div class="card-body">
+        <div class="card-body del-btn">
             <% @post.comments.includes(:author).each do |comment| %>
-             <p class="card-text"><%= comment.author.name %>: <%= comment.text %></p>
+             <p class="card-text p"><%= comment.author.name %>: <%= comment.text %></p>
+            <% if can? :destroy, comment %>
+                <%= button_to 'Delete Comment', user_post_comment_path(@post.author, @post.id, id: comment.id), method: :delete, data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, class: 'btn btn-danger btn-sm col-md-3 float-end' %>
+            <% end %>
+            <hr class="mt-5">
             <% end %>
         </div>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -33,7 +33,10 @@
 
          <div class="comment-like">
             <%= link_to 'Add Comment',  new_user_post_comment_path(@user, post), class: 'col-md-3 m-3 btn btn-secondary comment-btn' %>
-            <%= button_to 'Like',  user_post_likes_path(@user, post), method: :post, class: 'col-md-2 m-3 btn btn-secondary' %>
+            <%= button_to 'Like',  user_post_likes_path(@user, post), method: :post, class: 'col-md-2 m-3 btn btn-secondary comment-btn' %>
+        <% if can? :destroy, post %>
+            <%= button_to 'Delete Post', user_post_path(@user, post), method: :delete, data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, class: 'col-md-2 m-3 btn btn-danger col-md-3' %>
+        <% end %>
         </div>
 
     </div>

--- a/db/migrate/20231031173026_create_posts.rb
+++ b/db/migrate/20231031173026_create_posts.rb
@@ -1,7 +1,7 @@
 class CreatePosts < ActiveRecord::Migration[7.1]
   def change
     create_table :posts do |t|
-      t.references :author, foreign_key: { to_table: :users }
+      t.references :author, foreign_key: { to_table: :users, on_delete: :cascade, on_update: :cascade }
       t.string :title
       t.text :text
       t.integer :comments_counter

--- a/db/migrate/20231031173425_create_comments.rb
+++ b/db/migrate/20231031173425_create_comments.rb
@@ -1,8 +1,8 @@
 class CreateComments < ActiveRecord::Migration[7.1]
   def change
     create_table :comments do |t|
-      t.references :user, foreign_key: true
-      t.references :post, foreign_key: true
+      t.references :user, foreign_key:  { on_delete: :cascade, on_update: :cascade }
+      t.references :post, foreign_key:  { on_delete: :cascade, on_update: :cascade }
       t.text :text
       t.timestamps
     end

--- a/db/migrate/20231031174052_create_likes.rb
+++ b/db/migrate/20231031174052_create_likes.rb
@@ -1,8 +1,8 @@
 class CreateLikes < ActiveRecord::Migration[7.1]
   def change
     create_table :likes do |t|
-      t.references :user, foreign_key: true
-      t.references :post, foreign_key: true
+      t.references :user, foreign_key: { on_delete: :cascade, on_update: :cascade }
+      t.references :post, foreign_key: { on_delete: :cascade, on_update: :cascade }
       t.timestamps
     end
   end

--- a/db/migrate/20231115183317_add_role_to_users.rb
+++ b/db/migrate/20231115183317_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :role, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_15_043457) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_15_183317) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,14 +60,15 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_15_043457) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.string "role"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "comments", "posts"
-  add_foreign_key "comments", "users"
-  add_foreign_key "likes", "posts"
-  add_foreign_key "likes", "users"
-  add_foreign_key "posts", "users", column: "author_id"
+  add_foreign_key "comments", "posts", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "comments", "users", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "likes", "posts", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "likes", "users", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "posts", "users", column: "author_id", on_update: :cascade, on_delete: :cascade
 end


### PR DESCRIPTION
**Hi Reviewer 👋**

<hr />

In this PR, we implemented the following feature to the **my-blog** project:
- Installed CanCanCan in the project.
- Added a role column to the **users** table using migration.
- A user can delete a post if it is theirs or if they have an admin role (column role has value "admin"). Use CanCanCan for this
  - For that we implemented the post deleting functionality. Added the "Delete" button to the view and make sure that only authorized users can see it.
- A user can delete a comment if it is theirs or if they have an admin role (column role has value "admin"). Use CanCanCan for this authorization.
  - For that we implemented the comment deleting functionality. Added the "Delete" button to the view and make sure that only authorized users can see it.
-  Authorized users can see all users and their posts.

**_Tip: For adding "admin" role to the user, we added the "role" text field to the **edit account view** and it is accessible on navbar under the **Edit Account** tab._**